### PR TITLE
Fix GitHub Actions workflow file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Build eleventy-website
         run: spin build
         working-directory: .
-    - name: Build and deploy
+      - name: Build and deploy
         uses: fermyon/actions/spin/deploy@v1
         with:
           fermyon_token: ${{ secrets.FERMYON_CLOUD_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 public
 package-lock.json
+node_modules/
+.spin/


### PR DESCRIPTION
This PR fixes the GitHub Action workflow file and also updates .gitignore to prevent `.spin/` and `node_modules/` from being added to source control